### PR TITLE
added count=10000 to api_call parameters due to default limitation

### DIFF
--- a/plugins/modules/prtg.py
+++ b/plugins/modules/prtg.py
@@ -177,7 +177,7 @@ def main():
     if not device_id:
 
         # do an API call and get results
-        check_resp, check_info = api_call(module, '/api/table.json', {'content':'devices', 'output':'json', 'columns':'objid,device,host,group,active'})
+        check_resp, check_info = api_call(module, '/api/table.json', {'content':'devices', 'output':'json', 'columns':'objid,device,host,group,active', 'count':10000})
         
         if(validate_response(module, check_info) != 200):
             module.fail_json(msg='API request failed')


### PR DESCRIPTION
added count=10000 to api_call parameters due to default limitation of 1000

See https://kb.paessler.com/en/topic/54543-api-returning-incorrect-data