### PR TITLE
fix: UnboundLocalError: cannot access local variable 'dev' id device_…

### DIFF
--- a/plugins/modules/prtg.py
+++ b/plugins/modules/prtg.py
@@ -204,8 +204,9 @@ def main():
         check_resp.close()
 
         # check to see if device exists
-        if check_result['devices']:
-            device_id = dev['objid']
+        for dev in check_result['devices']:
+            if check_result['devices']:
+                device_id = dev['objid']
 
     
     # setup changed variable


### PR DESCRIPTION
if device_id is used in task i'll get an error

This fixes this Error if device_id is used (at least for me)

```txt
An exception occurred during task execution. To see the full traceback, use
-vvv. The error was: UnboundLocalError: cannot access local variable 'dev' where
it is not associated with a value
```